### PR TITLE
Make `drem` new work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/dragonruby-*-drgtk

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /dragonruby-*-drgtk
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,16 +69,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -113,10 +191,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "drem"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "zip",
 ]
 
 [[package]]
@@ -141,6 +274,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +304,24 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -176,6 +347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,10 +368,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
@@ -212,6 +430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,10 +450,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -243,6 +501,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +533,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "windows-sys"
@@ -319,3 +605,53 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ name = "drem"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "git2",
  "zip",
 ]
 
@@ -284,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +301,21 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "git2"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -312,6 +337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -362,10 +397,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.1+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -381,6 +465,24 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "password-hash"
@@ -404,6 +506,12 @@ dependencies = [
  "password-hash",
  "sha2",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkg-config"
@@ -517,10 +625,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -529,10 +658,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["cargo", "derive"] }
+zip = "0.6.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["cargo", "derive"] }
+git2 = "0.17.1"
 zip = "0.6.6"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,65 @@
-# DragonRuby Environment Manager
+# DragonRuby Environment Manager `drem`
 
 ![Rust action status](https://github.com/petros/drem/actions/workflows/rust.yml/badge.svg)
 
-This is a command line utility that helps with the following tasks:
-
-1. Start a new game that can be published as an open source project
-2. Clone an existing open source game within a DRGTK folder
-
-## Assumptions
-
-- The developer (you) has already downloaded a version of DRGTK somewhere on their system.
-- `drem` only works on macOS for now
+A command line utility written in Rust to help manage DragonRuby projects. This related to the [DragonRuby Game Toolkit](https://dragonruby.org/toolkit/game) (DRGTK).
 
 ## Usage
 
-```shell
-drem new <game-name> --drgtk <path-to-drgtk>
+### General help
+
 ```
+$ drew --help
+Usage: drem [COMMAND]
+
+Commands:
+  new   Create a new game
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+### Create a new game
+
+```
+$ drew new --help
+Create a new game
+
+Usage: drem new --name <name> --drgtk <drgtk>
+
+Options:
+  -n, --name <name>    Name of the new game
+  -g, --drgtk <drgtk>  Path to DRGTK zip to use
+  -h, --help           Print help
+```
+
+#### Example
+
+```
+$ drem new -n eggs -d ~/Downloads/dragonruby-game-toolkit-macos.zip
+```
+
+This will do the following:
+- Check if the referenced DRGTK zip file is a legitimate DRGTK.
+- Unzip the DRGTK zip file to a folder called `dragonruby-eggs-drgtk` in the current directory.
+- Add a `.gitkeep` file under `dragonruby-eggs-drgtk/mygame/data`, `dragonruby-eggs-drgtk/mygame/fonts`, and `dragonruby-eggs-drgtk/mygame/sounds`. This ensures that these folders are tracked by Git as they are empty by default.
+- Add a `.gitignore` file under `dragonruby-eggs-drgtk/mygame` that ignores `.DS_Store` files.
+- Initializes a git repository under `dragonruby-eggs-drgtk/mygame`.
+
+After that, the developer can start working on their game push `dragonruby-eggs-drgtk/mygame` to GitHub or elsewhere.
+
+## To do
+
+- [ ] Add support for Windows and Linux
+- [ ] Add support for cloning an existing game from GitHub or elsewhere
+- [ ] Figure out a mechanism to remember the DRGTK version used for a game
+
+## Assumptions
+
+- The developer has already downloaded a version of DRGTK somewhere on their system.
+- `drem` only works on macOS for now but should be easy to port to Windows and Linux.
+
+## Contributing
+
+Contributions are welcome. Please open an issue first to discuss what you would like to change if it's a bug, or a discussion if it's a feature request.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DragonRuby Environment Manager `drem`
+# `drem` (DragonRuby Environment Manager)
 
 ![Rust action status](https://github.com/petros/drem/actions/workflows/rust.yml/badge.svg)
 
-A command line utility written in Rust to help manage DragonRuby projects. This related to the [DragonRuby Game Toolkit](https://dragonruby.org/toolkit/game) (DRGTK).
+A command line utility written in Rust to help manage DragonRuby projects. This is related to the [DragonRuby Game Toolkit](https://dragonruby.org/toolkit/game) (DRGTK).
 
 ## Usage
 
@@ -21,6 +21,8 @@ Options:
 ```
 
 ### Create a new game
+
+It will create a local copy of DRGTK and initialize a new game under it in a way that will make it easy to push to GitHub or elsewhere.
 
 ```
 $ drew new --help
@@ -47,7 +49,7 @@ This will do the following:
 - Add a `.gitignore` file under `dragonruby-eggs-drgtk/mygame` that ignores `.DS_Store` files.
 - Initializes a git repository under `dragonruby-eggs-drgtk/mygame`.
 
-After that, the developer can start working on their game push `dragonruby-eggs-drgtk/mygame` to GitHub or elsewhere.
+After that, the developer can start working on their game and push `dragonruby-eggs-drgtk/mygame` to GitHub or elsewhere.
 
 ## To do
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,24 +36,6 @@ fn current_directory() -> PathBuf {
     std::env::current_dir().unwrap()
 }
 
-fn extract(drgtk: &PathBuf, name: String) -> Result<(), String> {
-    let reader = match File::open(dbg!(drgtk)) {
-        Ok(file) => file,
-        Err(error) => return Err(format!("Could not open DRGTK: {}", error)),
-    };
-    let mut archive = match ZipArchive::new(reader) {
-        Ok(archive) => archive,
-        Err(error) => return Err(format!("Could not read DRGTK: {}", error)),
-    };
-    let directory = current_directory().join(format!("dragonruby-{}-drgtk", name));
-    println!("Extracting to {:?}", directory);
-    let zip_result = match archive.extract(directory) {
-        Ok(_) => Ok(()),
-        Err(error) => Err(format!("Could not extract DRGTK: {}", error)),
-    };
-    zip_result
-}
-
 fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
     let reader = match File::open(dbg!(drgtk)) {
         Ok(file) => file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use clap::{Arg, Command};
 use git2::Repository;
 use std::io::Write;
-use std::str::FromStr;
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -43,7 +42,7 @@ fn current_directory() -> PathBuf {
     std::env::current_dir().unwrap()
 }
 
-fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
+fn perform_new_command(drgtk: &PathBuf, name: String) -> Result<(), String> {
     let reader = match File::open(drgtk) {
         Ok(file) => file,
         Err(error) => return Err(format!("Could not open DRGTK: {}", error)),
@@ -128,7 +127,7 @@ fn main() {
             if let Some(drgtk) = command.get_one::<PathBuf>("drgtk") {
                 println!("Using DRGTK: {:?}", drgtk);
                 if archive_is_drgtk(drgtk) {
-                    match unzip(drgtk, name.clone()) {
+                    match perform_new_command(drgtk, name.clone()) {
                         Ok(_) => {
                             println!("Done!");
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
             Ok(file) => file,
             Err(error) => return Err(format!("Could not read archive file: {}", error)),
         };
-        let outpath = file.sanitized_name();
+        let outpath = file.mangled_name();
 
         if (&*file.name()).starts_with("dragonruby-macos") {
             let new_path = Path::new(format!("dragonruby-{}-drgtk", name).as_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,100 @@
 use clap::{Arg, Command, Parser};
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+use zip::ZipArchive;
 
 #[derive(Parser, Debug)]
 #[command(author = "Petros Amoiridis", version, about, long_about = None)]
 struct Args {}
 
 const DEFAULT_GAME_NAME: &str = "mygame";
+
+fn files_exist_in_archive(drgtk: &PathBuf, files: &[&str]) -> bool {
+    let reader = File::open(drgtk).unwrap();
+    let mut archive = ZipArchive::new(reader).unwrap();
+    let mut result = true;
+    for file_name in files {
+        match archive.by_name(file_name) {
+            Ok(_) => {}
+            Err(_) => {
+                result = false;
+            }
+        }
+    }
+    result
+}
+
+fn archive_is_drgtk(drgtk: &PathBuf) -> bool {
+    files_exist_in_archive(
+        drgtk,
+        &[
+            "dragonruby-macos/dragonruby",
+            "dragonruby-macos/console-logo.png",
+        ],
+    )
+}
+
+fn current_directory() -> PathBuf {
+    std::env::current_dir().unwrap()
+}
+
+fn extract(drgtk: &PathBuf, name: String) -> Result<(), String> {
+    let reader = match File::open(dbg!(drgtk)) {
+        Ok(file) => file,
+        Err(error) => return Err(format!("Could not open DRGTK: {}", error)),
+    };
+    let mut archive = match ZipArchive::new(reader) {
+        Ok(archive) => archive,
+        Err(error) => return Err(format!("Could not read DRGTK: {}", error)),
+    };
+    let directory = current_directory().join(format!("dragonruby-{}-drgtk", name));
+    println!("Extracting to {:?}", directory);
+    let zip_result = match archive.extract(directory) {
+        Ok(_) => Ok(()),
+        Err(error) => Err(format!("Could not extract DRGTK: {}", error)),
+    };
+    zip_result
+}
+
+fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
+    let reader = match File::open(dbg!(drgtk)) {
+        Ok(file) => file,
+        Err(error) => return Err(format!("Could not open DRGTK: {}", error)),
+    };
+    let mut archive = match ZipArchive::new(reader) {
+        Ok(archive) => archive,
+        Err(error) => return Err(format!("Could not read DRGTK: {}", error)),
+    };
+    let directory = current_directory().join(format!("dragonruby-{}-drgtk", name));
+    println!("Extracting to {:?}", directory);
+    for i in 0..archive.len() {
+        let mut file = match archive.by_index(i) {
+            Ok(file) => file,
+            Err(error) => return Err(format!("Could not read archive file: {}", error)),
+        };
+        let outpath = file.sanitized_name();
+
+        if (&*file.name()).starts_with("dragonruby-macos") {
+            let new_path = Path::new(format!("dragonruby-{}-drgtk", name).as_str())
+                .join(outpath.strip_prefix("dragonruby-macos").unwrap());
+
+            if (&*file.name()).ends_with('/') {
+                std::fs::create_dir_all(&new_path).unwrap();
+            } else {
+                if let Some(p) = new_path.parent() {
+                    if !p.exists() {
+                        std::fs::create_dir_all(&p).unwrap();
+                    }
+                }
+                let mut outfile = std::fs::File::create(&new_path).unwrap();
+                std::io::copy(&mut file, &mut outfile).unwrap();
+            }
+        }
+    }
+    Ok(())
+}
 
 fn build_new() -> Command {
     let name = Arg::new("name")
@@ -34,9 +123,21 @@ fn main() {
     if let Some(command) = matches.subcommand_matches("new") {
         if let Some(name) = command.get_one::<String>("name") {
             println!("Creating new game: {}", name);
-        }
-        if let Some(drgtk) = command.get_one::<PathBuf>("drgtk") {
-            println!("Using DRGTK: {:?}", drgtk);
+            if let Some(drgtk) = command.get_one::<PathBuf>("drgtk") {
+                println!("Using DRGTK: {:?}", drgtk);
+                if archive_is_drgtk(drgtk) {
+                    match unzip(drgtk, name.clone()) {
+                        Ok(_) => {
+                            println!("Done!");
+                        }
+                        Err(e) => {
+                            println!("Error: {}", e);
+                        }
+                    }
+                } else {
+                    println!("DRGTK is not a valid macOS archive");
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Arg, Command};
+use std::io::Write;
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -28,6 +29,12 @@ fn archive_is_drgtk(drgtk: &PathBuf) -> bool {
             "dragonruby-macos/console-logo.png",
         ],
     )
+}
+
+fn create_gitignore(path: &Path) {
+    let mut gitignore =
+        File::create(path.join(".gitignore")).expect("Could not create .gitignore file");
+    writeln!(gitignore, ".DS_Store").expect("Could not write to .gitignore file");
 }
 
 fn current_directory() -> PathBuf {
@@ -64,6 +71,10 @@ fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
                 {
                     let gitkeep_path = new_path.join(".gitkeep");
                     File::create(gitkeep_path).expect("Could not create .gitkeep file");
+                }
+                if new_path.ends_with("mygame") {
+                    // Create the .gitignore file
+                    create_gitignore(&new_path);
                 }
             } else {
                 if let Some(p) = new_path.parent() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,13 @@ fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
 
             if (&*file.name()).ends_with('/') {
                 std::fs::create_dir_all(&new_path).unwrap();
+                if new_path.ends_with("mygame/data")
+                    || new_path.ends_with("mygame/fonts")
+                    || new_path.ends_with("mygame/sounds")
+                {
+                    let gitkeep_path = new_path.join(".gitkeep");
+                    File::create(gitkeep_path).expect("Could not create .gitkeep file");
+                }
             } else {
                 if let Some(p) = new_path.parent() {
                     if !p.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{Arg, Command};
+use git2::Repository;
 use std::io::Write;
+use std::str::FromStr;
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -60,8 +62,8 @@ fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
         let outpath = file.mangled_name();
 
         if (&*file.name()).starts_with("dragonruby-macos") {
-            let new_path = Path::new(format!("dragonruby-{}-drgtk", name).as_str())
-                .join(outpath.strip_prefix("dragonruby-macos").unwrap());
+            let new_path =
+                Path::new(&directory).join(outpath.strip_prefix("dragonruby-macos").unwrap());
 
             if (&*file.name()).ends_with('/') {
                 std::fs::create_dir_all(&new_path).unwrap();
@@ -87,6 +89,12 @@ fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
             }
         }
     }
+    git_init(&Path::new(&directory).join("mygame")).expect("Could not initialize git repository");
+    Ok(())
+}
+
+fn git_init(path: &Path) -> Result<(), git2::Error> {
+    Repository::init(path)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,6 @@ use std::{
 };
 use zip::ZipArchive;
 
-#[derive(Parser, Debug)]
-#[command(author = "Petros Amoiridis", version, about, long_about = None)]
-struct Args {}
-
 const DEFAULT_GAME_NAME: &str = "mygame";
 
 fn files_exist_in_archive(drgtk: &PathBuf, files: &[&str]) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn current_directory() -> PathBuf {
 }
 
 fn unzip(drgtk: &PathBuf, name: String) -> Result<(), String> {
-    let reader = match File::open(dbg!(drgtk)) {
+    let reader = match File::open(drgtk) {
         Ok(file) => file,
         Err(error) => return Err(format!("Could not open DRGTK: {}", error)),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
-use clap::{Arg, Command, Parser};
+use clap::{Arg, Command};
 use std::{
     fs::File,
     path::{Path, PathBuf},
 };
 use zip::ZipArchive;
-
-const DEFAULT_GAME_NAME: &str = "mygame";
 
 fn files_exist_in_archive(drgtk: &PathBuf, files: &[&str]) -> bool {
     let reader = File::open(drgtk).unwrap();
@@ -78,7 +76,7 @@ fn build_new() -> Command {
     let name = Arg::new("name")
         .short('n')
         .long("name")
-        .default_value(DEFAULT_GAME_NAME)
+        .required(true)
         .help("Name of the new game");
     let drgtk = Arg::new("drgtk")
         .short('g')


### PR DESCRIPTION
I want to make `drem new -n egg-catcher -d ~/Downloads/dragonruby-pro-macos.zip` work. Check the [card](https://3.basecamp.com/3947102/buckets/32934730/card_tables/cards/6197884023) on Basecamp.